### PR TITLE
lcd_tearing_effect is an input

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -91,9 +91,7 @@ const APP: () = {
 
         lcd_extd_command.set_high().unwrap();
 
-        let mut lcd_tearing_effect = gpiob.pb11.into_push_pull_output();
-
-        lcd_tearing_effect.set_high().unwrap();
+        let _lcd_tearing_effect = gpiob.pb11.into_floating_input();
 
         let lcd_pins = LcdPins {
             data: (


### PR DESCRIPTION
I just tried to run this project on my Numworks calculator and the non FSMC version did work instantly. It's great to see embedded-graphics working on a calculator.

But I have noticed that the `lcd_tearing_effect` signal is incorrectly initialized as an output instead of an input.
