### PR TITLE
Set speed for QSPI pins

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ extern crate alloc;
 
 use alloc::format;
 use alloc_cortex_m::CortexMHeap;
+use stm32f7xx_hal::gpio::Speed;
 use core::alloc::Layout;
 use core::slice;
 
@@ -68,12 +69,12 @@ const APP: () = {
         // Take ownership of the QSPI pins (to prevent them from being messed with later) and set
         // them to the correct modes.
         let qspi_pins = (
-            gpiob.pb2.into_alternate_af9(),
-            gpiob.pb6.into_alternate_af10(),
-            gpioc.pc9.into_alternate_af9(),
-            gpiod.pd12.into_alternate_af9(),
-            gpiod.pd13.into_alternate_af9(),
-            gpioe.pe2.into_alternate_af9(),
+            gpiob.pb2.into_alternate_af9().set_speed(Speed::VeryHigh),
+            gpiob.pb6.into_alternate_af10().set_speed(Speed::VeryHigh),
+            gpioc.pc9.into_alternate_af9().set_speed(Speed::VeryHigh),
+            gpiod.pd12.into_alternate_af9().set_speed(Speed::VeryHigh),
+            gpiod.pd13.into_alternate_af9().set_speed(Speed::VeryHigh),
+            gpioe.pe2.into_alternate_af9().set_speed(Speed::VeryHigh),
         );
 
         // Setup external flash over QSPI.


### PR DESCRIPTION
This might help you get the QSPI flash working. I didn't have time to look at the actual QSPI communication, but this should be a step in the right direction.

I've hooked up my calculator to a logic analyzer to check the QSPI communication and noticed that it seemed that there was no activity on the clock output. After increasing the speed setting for the QSPI pins the clock signal works correctly.

The display output has changed from all `00`s to all `ff`s, but I didn't try to execute the mass erase or flashing operations yet.