### PR TITLE
Port to embedded-graphics 0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "az"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "822d7d63e0c0260a050f6b1f0d316f5c79b9eab830aca526ed904e1011bd64ca"
+
+[[package]]
 name = "bare-metal"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,10 +230,24 @@ dependencies = [
 
 [[package]]
 name = "embedded-graphics"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a69991ceb896bd4810a0cf2bcc46fc94b7860573c71f965d8e5b3d66942fed"
+checksum = "750082c65094fbcc4baf9ba31583ce9a8bb7f52cadfb96f6164b1bc7f922f32b"
 dependencies = [
+ "az",
+ "byteorder",
+ "embedded-graphics-core",
+ "float-cmp",
+ "micromath",
+]
+
+[[package]]
+name = "embedded-graphics-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3902d8d4422aa9ac75556f8cfb2e02c8ba22eb3f1993aec8bc113e6299b2da"
+dependencies = [
+ "az",
  "byteorder",
 ]
 
@@ -243,11 +263,21 @@ dependencies = [
 
 [[package]]
 name = "embedded-text"
-version = "0.4.1"
+version = "0.5.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "834a6ae98d7760b01f15ea11eb46bcbee582878dd634a64bc9204ae295946adb"
+checksum = "678b7f931bc28619453685226c11083dcf124cd2ec55a63248281f3754702070"
 dependencies = [
+ "az",
  "embedded-graphics",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1267f4ac4f343772758f7b1bdcbe767c218bbab93bb432acbf5162bbf85a6c4"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -301,18 +331,6 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
-
-[[package]]
-name = "heapless"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74911a68a1658cfcfb61bc0ccfbd536e3b6e906f8c2f7883ee50157e3e2184f1"
-dependencies = [
- "as-slice",
- "generic-array 0.13.3",
- "hash32 0.1.1",
- "stable_deref_trait",
-]
 
 [[package]]
 name = "heapless"
@@ -531,15 +549,14 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "st7789"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f2a309b876ab3ac011a437624b439ec22387db20c86e024b5aae8090428623"
+version = "0.6.0"
+source = "git+https://github.com/almindor/st7789?branch=eg070#67248db707e63441be9a7efb59a4186d26ab1371"
 dependencies = [
  "display-interface",
  "embedded-graphics",
  "embedded-hal",
- "heapless 0.5.6",
- "nb 0.1.3",
+ "heapless 0.7.3",
+ "nb 1.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ cortex-m-rt = "0.6"
 rtt-target = { version = "0.3", features = ["cortex-m"] }
 embedded-hal = "0.2"
 cortex-m-rtic = "0.5"
-embedded-graphics = "0.6"
-embedded-text = { version = "0.4", default-features = false }
+embedded-graphics = "0.7"
+embedded-text = { version = "0.5.0-beta.1", default-features = false }
 heapless = "0.7"
-st7789 = { version = "0.5", features = ["batch"] }
+st7789 = { git = "https://github.com/almindor/st7789", branch = "eg070", features = ["batch"] }
 display-interface-parallel-gpio = "0.6"
 stm32f7xx-hal = { git = "https://github.com/willemml/stm32f7xx-hal", branch = "fmc_lcd", features = ["stm32f730", "rt", "fmc_lcd"] }
 num-traits = { version = "0.2", default-features = false }


### PR DESCRIPTION
This PR updates e-g to 0.7.

I wanted to try some e-g features on real hardware and needed version 0.7 for that. The `st7789` driver isn't released yet and I had to use a git dependency. I'm not sure if you want to merge this now or wait until the driver is released.