### PR TITLE
Fix FMC timings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -555,7 +555,6 @@ dependencies = [
  "display-interface",
  "embedded-graphics",
  "embedded-hal",
- "heapless 0.7.3",
  "nb 1.0.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ cortex-m-rtic = "0.5"
 embedded-graphics = "0.7"
 embedded-text = { version = "0.5.0-beta.1", default-features = false }
 heapless = "0.7"
-st7789 = { git = "https://github.com/almindor/st7789", branch = "eg070", features = ["batch"] }
+st7789 = { git = "https://github.com/almindor/st7789", branch = "eg070", default-features = false, features = ["graphics"] }
 display-interface-parallel-gpio = "0.6"
 stm32f7xx-hal = { git = "https://github.com/willemml/stm32f7xx-hal", branch = "fmc_lcd", features = ["stm32f730", "rt", "fmc_lcd"] }
 num-traits = { version = "0.2", default-features = false }

--- a/src/display.rs
+++ b/src/display.rs
@@ -98,7 +98,7 @@ impl Display {
         delay: &mut Delay,
         clocks: &Clocks,
     ) -> Self {
-        let ns_to_cycles = |ns: u32| (clocks.hclk().0 / 1_000_000) * ns;
+        let ns_to_cycles = |ns: u32| (clocks.hclk().0 / 1_000_000) * ns / 1000;
 
         let tedge: u32 = 15;
         let twc: u32 = 66;
@@ -115,6 +115,8 @@ impl Display {
         let read_timing = Timing::default()
             .data(read_data_cycles as u8)
             .address_setup(read_addrsetup_cycles as u8)
+            .address_hold(0)
+            .bus_turnaround(0)
             .access_mode(AccessMode::ModeA);
 
         let twdatast = twrl + tedge;
@@ -126,6 +128,8 @@ impl Display {
         let write_timing = Timing::default()
             .data(write_data_cycles as u8)
             .address_setup(write_addrsetup_cycles as u8)
+            .address_hold(0)
+            .bus_turnaround(0)
             .access_mode(AccessMode::ModeA);
 
         power_pin.set_high().unwrap();


### PR DESCRIPTION
The output `ns_to_cycles` function was off by a factor of 1000. The resulting values are later cast to `u8` which masks the problem that the output of `ns_to_cycles` is larger than 255.

The WE signal is now low for 28 ns instead of 376 ns, which is closer to the minimum timing. The overall drawing performance hasn't improved as much (only 10% - 30%), but I think the bottleneck is now the software and not the FMC controller. With the old timing values the CS line didn't toggle during a display `clear`, which probably means that the write FIFO was never empty. But with the new values the CS line toggles for each byte and I believe that the software isn't fast enough to keep the FIFO filled.